### PR TITLE
Added note about the namespace that contains the dialogs.

### DIFF
--- a/controls/dialogs.md
+++ b/controls/dialogs.md
@@ -3,7 +3,7 @@ layout: no-sidebar
 title: Dialogs
 ---
 
-Since the built-in WPF dialogs are unstyleable, we had to create our own implementation.
+Since the built-in WPF dialogs are unstyleable, we had to create our own implementation. You will find our dialogs within the MahApps.Metro.Controls.Dialogs namespace.
 
 <img src="{{site.baseurl}}/images/dialog.png" style="width: 800px;"/>
 


### PR DESCRIPTION
It's useful to know which namespaces need adding. (Or even that a namespace needs adding at all, beyond just MahApps.Metro.Controls.) Adding this to the docs should stop stupid help requests from people like me!
