### PR TITLE
Update Guides\index.md

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -4,7 +4,7 @@ title: Guides
 ---
 
  - [Quick Start](quick-start.html)
- - [Advanced Guide](advanced-guide.html)
+ - [Advanced MetroWindow Guide](advanced-guide.html)
  - [Icons and Resources](icons-and-resources.html)
  - [Styles](styles.html)
  - [Reporting Issues](reporting-issues.html)


### PR DESCRIPTION
Updated the Advanced Guide link text to Advanced MetroWindow Guide, which is more appropriate for the linked page and easier to find.