### PR TITLE
Fix overflow on pre,code tags

### DIFF
--- a/css/style-custom.css
+++ b/css/style-custom.css
@@ -1,9 +1,10 @@
 pre, code {
-	font-family: 'Source Code Pro', sans-serif;
-	font-weight: 500;
-	font-size: 0.9em;
+  font-family: 'Source Code Pro', sans-serif;
+  font-weight: 500;
+  font-size: 0.9em;
   line-height: normal;
   background-color: #F2F2F2;
+  overflow: auto;
 }
 
 blockquote {


### PR DESCRIPTION
Code sections on the site using the pre tag were overflowing out of their container. If this is intentional then just ignore this change.

![Screen Shot 2019-08-15 at 3 14 41 PM](https://user-images.githubusercontent.com/10855502/63123928-c2ae7900-bf6f-11e9-8c4e-d90de37b2795.png)
